### PR TITLE
Clarified the help pages a bit

### DIFF
--- a/main/templates/main/help.html
+++ b/main/templates/main/help.html
@@ -26,9 +26,9 @@
         <div class="panel-group uu-panel mt-4">
             {% include 'main/help_parts/general.html' %}
             {% include 'main/help_parts/webdav.html' %}
-            {% include 'main/help_parts/developer.html' %}
             {% include 'main/help_parts/session.html' %}
             {% include 'main/help_parts/faq.html' %}
+            {% include 'main/help_parts/developer.html' %}
         </div>
         <br/>
     </div>

--- a/main/templates/main/help_parts/general.html
+++ b/main/templates/main/help_parts/general.html
@@ -78,9 +78,14 @@
                 how to mount the webshare can be found in the block below.
             </p>
             <p>
-                Make sure the main HTML file is called <i>index.html</i>.
+                Make sure the HTML file is called <i>index.html</i>.
                 Otherwise, the server cannot find which file should be displayed
                 without explicitly adding it to the URL.
+            </p>
+            <p>
+                There might already be a file called <i>index.html</i> in your
+                folder, as we place a placeholder page when creating new
+                folders. It's safe to overwrite this file.
             </p>
             <h4>
                 Step 5: Open your experiment

--- a/main/templates/main/help_parts/session.html
+++ b/main/templates/main/help_parts/session.html
@@ -53,10 +53,11 @@
 
             <h4>Implementation</h4>
             <p>
-              If you would like to use target groups with one of our jsPsych templates, look for a section in index.html that starts with:
-              <p><code>// Option 1: client side randomization:</code></p>
-              and comment out the part below it. Then uncomment the section following:
-              <p><code>// Option 2: server side balancing:</code></p>
+              If you would like to use target groups with one of our jsPsych templates, look for a section in <code>main.js</code> that starts with:<br/>
+              <code>// Option 1: client side randomization:</code><br/>
+              and comment out the part below it. Then uncomment the section following:<br/>
+              <code>// Option 2: server side balancing:</code><br/>
+              (Note: in older templates these sections are located in <code>index.html</code> instead.)
             </p>
             <p>
               Make sure your experiment is set to Open for target groups to work.

--- a/main/templates/main/help_parts/webdav.html
+++ b/main/templates/main/help_parts/webdav.html
@@ -17,7 +17,7 @@
             </p>
             <p>
                 You can find the location of your share on the details page of
-                your experiment.
+                your experiment. (Under 'location' in the sidebar, it should start with 'webdav')
             </p>
             <h3>On Windows</h3>
             <ol>


### PR DESCRIPTION
We got feedback that some students were a bit confused by the help pages, so the following changes were made:

- Moving the developer section to the bottom of the page, as 99% of people don't need to do anything there. Moving it to the bottom helps students ignore it
- Removed the word 'main' from 'main HTML file' as students were confused as there's also a 'main.js' file in some of our boilerplates. (They thought they might need to rename that file to index.html). As there's only one HTML file in an experiment most of the time, the word 'main' was redundant anyway.
- Continueing on from the html confusing: students were afraid of overwriting our placeholder HTML, so I added a paragraph telling them it's safe
- Lastly, people didn't catch the difference between the location and webdav urls and were trying to use the location url as the webdav share url. Hopefully this small addition helps avoiding that from now on