### PR TITLE
fix: Added webdav connect instructions for the lab pcs

### DIFF
--- a/main/templates/main/help_parts/webdav.html
+++ b/main/templates/main/help_parts/webdav.html
@@ -64,6 +64,26 @@
                 Make sure your experiment's main HTML file is called <i>index.html</i>!
             </p>
             <h3>On Linux</h3>
+            <h4>In the Lab (Mate)</h4>
+            <ol>
+                <li>
+                    Open the file manager (Caja)
+                </li>
+                <li>
+                    Select the URI bar or press CTRL+L
+                </li>
+                <li>
+                    Insert davs://{the URL listed on your experiment page}<br/>
+                    (Do not forget to add the <i>davs://</i>)
+                </li>
+                <li>
+                    Provide queried credentials (Solis-ID)
+                </li>
+            </ol>
+            <p>
+                You should now have access to your folder. Upload your experiment by copying the files to this folder.
+                Make sure your experiment's main HTML file is called <i>index.html</i>!
+            </p>
             <h4>KDE (Kubuntu, OpenSUSE)</h4>
             <ol>
                 <li>


### PR DESCRIPTION
We have instructions for Gnome and KDE, but for Mate you actually have to do a hybrid of the two. This PR adds specific instructions for Mate (that is clearly labeled as for lab-pc's)