### PR TITLE
avoid eagerly loading DataPoint.data

### DIFF
--- a/experiments/utils/download.py
+++ b/experiments/utils/download.py
@@ -82,10 +82,12 @@ def create_download_response_zip(
             queryset
         )
 
-    return FileResponse(
+    response = FileResponse(
         zip_file,
-        filename="{}-{}.zip".format(experiment.title, file_format)
-    )
+        content_type='application/zip',
+        )
+    response['Content-Disposition'] = 'attachment; filename="{}-{}.zip"'.format(experiment.title, file_format)
+    return response
 
 
 def create_file_response_single(file_format: str, data_point: DataPoint) -> \
@@ -123,6 +125,24 @@ def create_file_response_single(file_format: str, data_point: DataPoint) -> \
     return response
 
 
+class StreamingIO:
+    def __init__(self):
+        self.buffer = io.BytesIO()
+
+    def write(self, data):
+        return self.buffer.write(data)
+
+    def flush(self):
+        return self.buffer.flush()
+
+    def reset(self):
+        del self.buffer
+        self.buffer = io.BytesIO()
+
+    def getvalue(self):
+        return self.buffer.getvalue()
+
+
 def _create_zip(
         experiment: Experiment,
         filename_generator: callable,
@@ -137,13 +157,13 @@ def _create_zip(
     :param processor: a callable that produces the data in the intended
     format when given a datapoint object
     """
-    buffer = io.BytesIO()
+    buffer = StreamingIO()
 
-    with zipfile.ZipFile(buffer, "a", zipfile.ZIP_DEFLATED, True) as zip_file:
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED, True) as zip_file:
         export_report = EXPORT_REPORT_HEADER
 
         if queryset is None:
-            queryset = experiment.datapoint_set.all()
+            queryset = experiment.datapoint_set.all().defer('data')
 
         for dataPoint in queryset:
             filename = filename_generator(dataPoint)
@@ -154,13 +174,11 @@ def _create_zip(
             except Exception as e:
                 export_report += "-{} - FAILED\n".format(filename)
 
+            yield buffer.getvalue()
+            buffer.reset()
         zip_file.writestr("export_report.txt", export_report)
 
-    # Reset the buffer cursor to the start, so FileResponse reads the entire
-    # buffer
-    buffer.seek(0)
-
-    return buffer
+    yield buffer.getvalue()
 
 
 def _flatten_json(data: str) -> str:

--- a/experiments/views.py
+++ b/experiments/views.py
@@ -333,5 +333,5 @@ class DownloadFormView(UserAllowedMixin, generic.FormView):
         file_format = form.cleaned_data['file_format']
         queryset = self.experiment.datapoint_set \
             .filter(session__experiment_state__in=form.cleaned_data['include_status']) \
-            .filter(session__group__in=form.cleaned_data['include_groups'])
+            .filter(session__group__in=form.cleaned_data['include_groups']).defer('data')
         return create_download_response_zip(file_format, self.experiment, queryset)

--- a/experiments/views.py
+++ b/experiments/views.py
@@ -183,7 +183,7 @@ class ExperimentDetailView(UserAllowedMixin, generic.ListView):
         return context
 
     def get_queryset(self):
-        return self.model.objects.filter(experiment=self.experiment)
+        return self.model.objects.filter(experiment=self.experiment).defer('data')
 
 
 class DeleteExperimentView(UserAllowedMixin, SuccessMessageMixin,


### PR DESCRIPTION
This should help avoid OOM when just looking at an experiment that has large DataPoints